### PR TITLE
Enable to run on Gitlab-CI

### DIFF
--- a/index.js
+++ b/index.js
@@ -139,7 +139,8 @@ if (require.main === module) {
 
     if (!options.output) {
         let baseName = path.parse(options.file).name;
-        options.output = `${baseName}.${options.type}`;
+        let directoryName = path.parse(options.file).dir;
+        options.output = `${directoryName}/${baseName}.${options.type}`;
     }
 
     const bpmnXML = fs.readFileSync(options.file, {encoding: 'utf-8'});

--- a/index.js
+++ b/index.js
@@ -49,7 +49,9 @@ async function renderDiagram(bpmnXML, options) {
                 height: options.height,
                 landscape: true,
                 deviceScaleFactor: 2
-            }
+            },
+            args: ['--no-sandbox'],
+            executablePath: process.env.CHROMIUM_PATH
         });
 
         const page = await browser.newPage();


### PR DESCRIPTION
This merge request disables the Chrome sandbox to be able to run it as a job in Gitlab-CI.

For this I also adde that image files will be output in the same directory as the source, to be able to preserve the structure.

My Dockerfile
```
FROM buildkite/puppeteer AS dependencies
RUN apt-get update; apt-get install -y git
ENV PATH="${PATH}:/node_modules/.bin"
ENV CHROMIUM_PATH="/usr/bin/google-chrome"
ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD="true"

RUN npm install --save -g github:indero/bpmn-js-cmd#docker_container

FROM dependencies
USER 1001
WORKDIR /app
ENTRYPOINT ["bpmn-js"]
```

And my current .gitlab-ci.yaml
```yaml
image: alpine:latest

variables:
  DOCKER_DRIVER: overlay2

stages:
  - convert

convert-to-images:
  stage: convert
  image:
    name: $CI_REGISTRY/<group>/<project>/docker:latest
    entrypoint: [""]
  before_script:
    - mkdir output
  script:
    - time find . -name \*.bpmn -type f -print0 | xargs -0 -n1 -P8 bpmn-js
    - time find . -name \*.bpmn -type f -print0 | xargs -0 -n1 -P8 bpmn-js -t png
  after_script:
    - find \( -name "*.svg" -o -name "*.png" -type f \) -print0 | xargs -0 -n1 -P8 -I '{}' mv '{}' output/
  artifacts:
    paths:
      - output
    expire_in: 1 month
```

Maybe the sandbox disabling needs to be added as an Option?